### PR TITLE
Add OpenBoard code signature verification

### DIFF
--- a/OpenBoard/OpenBoard.download.recipe
+++ b/OpenBoard/OpenBoard.download.recipe
@@ -39,6 +39,17 @@
 			<key>Processor</key>
 			<string>EndOfCheckPhase</string>
 		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>input_path</key>
+				<string>%pathname%/OpenBoard.app</string>
+				<key>requirement</key>
+				<string>identifier "org.oe-f.OpenBoard" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "32B6LPAVCU"</string>
+			</dict>
+			<key>Processor</key>
+			<string>CodeSignatureVerifier</string>
+		</dict>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
As of 1.5.0 OpenBoard release, app is now code signed. Test run successfully verifies code signature.

Pertinent verbose output from test run:

```
GitHubReleasesInfoProvider
{'Input': {'github_repo': u'OpenBoard-org/OpenBoard'}}
GitHubReleasesInfoProvider: Selected asset 'OpenBoard-1.5.0.dmg' from release 'v1.5.0'
{'Output': {'release_notes': u'## Version 1.5.0\r\n### New features\r\n#### A whole new Document mode\r\nA major overhaul of the Document mode has been carried out. \r\n\r\n##### Documents tree structure\r\nYou can now create complex tree structures to organize your work. The "Untitled Documents" folder is no longer relevant and, if exists from a previous installation, can be deleted. You can adjust the size of the documents tree area by playing with the vertical splitter between it and the thumbnails area.\r\n\r\n##### Sortable documents\r\nDocuments can be sorted, using the "Sort Kind" drop down list and the "Sort Order" icon beside, by creation date, modification date, or alphabetical order. A second column displays the date of creation or modification.\r\n\r\n##### Icons on Folders and Documents\r\nNew icons have been added to the document tree structure to improve readability and help navigation.\r\n\r\n##### Export/Import a folder\r\nYou can now export an entire folder (including the "My Documents" folder), using the new option "Export to OpenBoard UBX" in the Export menu. The exported hierarchy is preserved at import.\r\n\r\n#### Mac Certification\r\nOpenBoard for macOS is now signed, allowing it to be recognized by Gatekeeper.\r\n\r\n#### New Translations\r\nTranslations for Ukrainian and Hungarian has been started and added to the supported languages.\r\n\r\n#### Widgets\r\nA new version of the GraphMe widget has been integrated.\r\n\r\n\r\n### Bug fixes\r\n* It was no longer possible to freely resize the mask\r\n* The tab on the library panel could disappear in some cases\r\n\r\n### Known issues\r\n* This redesign of the Documents mode was a complex development and several small cosmetic bugs may still remain, including focus issues\r\n* Folders in the trash of your OpenBoard 1.4 installation are renamed _Trash:folder_name in the 1.5 version and are found in My Documents. They can be put in the Trash. \r\n* Some slow motion can be experienced in MacOS while using drag and drop in the new document tree structure.',
            'url': u'https://github.com/OpenBoard-org/OpenBoard/releases/download/v1.5.0/OpenBoard-1.5.0.dmg',
            'version': u'1.5.0'}}
URLDownloader
{'Input': {'filename': u'OpenBoard-1.5.0.dmg',
           'url': u'https://github.com/OpenBoard-org/OpenBoard/releases/download/v1.5.0/OpenBoard-1.5.0.dmg'}}
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
URLDownloader: Storing new Last-Modified header: Thu, 29 Nov 2018 10:14:33 GMT
URLDownloader: Storing new ETag header: "596ab09f6121fdd7db6fee820837c63b"
URLDownloader: Downloaded /Volumes/1TB/AutoPkgr/Cache/com.github.sebtomasi.download.OpenBoard/downloads/OpenBoard-1.5.0.dmg
{'Output': {'download_changed': True,
            'etag': '"596ab09f6121fdd7db6fee820837c63b"',
            'last_modified': 'Thu, 29 Nov 2018 10:14:33 GMT',
            'pathname': u'/Volumes/1TB/AutoPkgr/Cache/com.github.sebtomasi.download.OpenBoard/downloads/OpenBoard-1.5.0.dmg',
            'url_downloader_summary_result': {'data': {'download_path': u'/Volumes/1TB/AutoPkgr/Cache/com.github.sebtomasi.download.OpenBoard/downloads/OpenBoard-1.5.0.dmg'},
                                              'summary_text': 'The following new items were downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': u'/Volumes/1TB/AutoPkgr/Cache/com.github.sebtomasi.download.OpenBoard/downloads/OpenBoard-1.5.0.dmg/OpenBoard.app',
           'requirement': u'identifier "org.oe-f.OpenBoard" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "32B6LPAVCU"'}}
CodeSignatureVerifier: Mounted disk image /Volumes/1TB/AutoPkgr/Cache/com.github.sebtomasi.download.OpenBoard/downloads/OpenBoard-1.5.0.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.ZJtOCV/OpenBoard.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.ZJtOCV/OpenBoard.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.ZJtOCV/OpenBoard.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
```