### PR TITLE
Remove NAME variable from app paths

### DIFF
--- a/Anki/Anki.pkg.recipe
+++ b/Anki/Anki.pkg.recipe
@@ -37,9 +37,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>source_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/Anki.app</string>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/Anki.app</string>
 			</dict>
 		</dict>
         <dict>
@@ -48,7 +48,7 @@
             <key>Arguments</key>
             <dict>
                 <key>info_path</key>
-                <string>%pkgroot%/Applications/%NAME%.app</string>
+                <string>%pkgroot%/Applications/Anki.app</string>
                 <key>plist_keys</key>
                 <dict>
                     <key>CFBundleShortVersionString</key>

--- a/Batch Image Resizer/BatchImageResizer.pkg.recipe
+++ b/Batch Image Resizer/BatchImageResizer.pkg.recipe
@@ -50,7 +50,7 @@
             <key>Arguments</key>
             <dict>
                 <key>info_path</key>
-                <string>%pkgroot%/Applications/%NAME%.app</string>
+                <string>%pkgroot%/Applications/BatchImageResizer.app</string>
                 <key>plist_keys</key>
                 <dict>
                     <key>CFBundleShortVersionString</key>

--- a/CaRMetal/CaRMetal.pkg.recipe
+++ b/CaRMetal/CaRMetal.pkg.recipe
@@ -37,9 +37,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>source_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/CARMetal.app</string>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/CARMetal.app</string>
 			</dict>
 		</dict>
         <dict>
@@ -48,7 +48,7 @@
             <key>Arguments</key>
             <dict>
                 <key>info_path</key>
-                <string>%pkgroot%/Applications/%NAME%.app</string>
+                <string>%pkgroot%/Applications/CARMetal.app</string>
                 <key>plist_keys</key>
                 <dict>
                     <key>CFBundleShortVersionString</key>

--- a/Intaglio/Intaglio.pkg.recipe
+++ b/Intaglio/Intaglio.pkg.recipe
@@ -56,7 +56,7 @@
                 <key>Arguments</key>
                 <dict>
                     <key>info_path</key>
-                    <string>%pathname%/%NAME%.app/Contents/Info.plist</string>
+                    <string>%pathname%/Intaglio.app/Contents/Info.plist</string>
                     <key>plist_keys</key>
                     <dict>
                         <key>CFBundleShortVersionString</key>
@@ -110,9 +110,9 @@
                 <key>Arguments</key>
                 <dict>
                     <key>source_path</key>
-                    <string>%pathname%/%NAME%.app</string>
+                    <string>%pathname%/Intaglio.app</string>
                     <key>destination_path</key>
-                    <string>%pkgroot%/Applications/%NAME%.app</string>
+                    <string>%pkgroot%/Applications/Intaglio.app</string>
                 </dict>
             </dict>
             <dict>

--- a/JetPhoto Studio/JetPhotoStudio.pkg.recipe
+++ b/JetPhoto Studio/JetPhotoStudio.pkg.recipe
@@ -37,9 +37,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>source_path</key>
-				<string>%RECIPE_CACHE_DIR%/downloads/%parsed_string%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/downloads/%parsed_string%/JetPhoto Studio.app</string>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/JetPhoto Studio.app</string>
 			</dict>
 		</dict>
         <dict>
@@ -48,7 +48,7 @@
             <key>Arguments</key>
             <dict>
                 <key>info_path</key>
-                <string>%pkgroot%/Applications/%NAME%.app</string>
+                <string>%pkgroot%/Applications/JetPhoto Studio.app</string>
                 <key>plist_keys</key>
                 <dict>
                     <key>CFBundleShortVersionString</key>

--- a/LibreOffice/LibreOfficeLangPack.pkg.recipe
+++ b/LibreOffice/LibreOfficeLangPack.pkg.recipe
@@ -75,7 +75,7 @@
 				<key>archive_path</key>
 				<string>%RECIPE_CACHE_DIR%/tarball.tar.bz2</string>
 				<key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/LibreOffice.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>Unarchiver</string>

--- a/OpenBoard/OpenBoard.pkg.recipe
+++ b/OpenBoard/OpenBoard.pkg.recipe
@@ -48,9 +48,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/OpenBoard.app</string>
 				<key>source_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/OpenBoard.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>Copier</string>

--- a/SplashBuddy/SplashBuddy.pkg.recipe
+++ b/SplashBuddy/SplashBuddy.pkg.recipe
@@ -34,7 +34,7 @@
                     <key>force_pkg_build</key>
                     <string>True</string>
                     <key>app_path</key>
-                    <string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+                    <string>%RECIPE_CACHE_DIR%/%NAME%/SplashBuddy.app</string>
                 </dict>
             </dict>
             <dict>
@@ -43,7 +43,7 @@
                 <key>Arguments</key>
                 <dict>
                     <key>input_path</key>
-                    <string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+                    <string>%RECIPE_CACHE_DIR%/%NAME%/SplashBuddy.app</string>
                     <key>requirement</key>
                     <string>anchor apple generic and identifier "io.fti.SplashBuddy" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "5G89W3T34F")</string>
                 </dict>

--- a/XMind/XMind.pkg.recipe
+++ b/XMind/XMind.pkg.recipe
@@ -37,9 +37,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>source_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/XMind.app</string>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/XMind.app</string>
 			</dict>
 		</dict>
         <dict>
@@ -48,7 +48,7 @@
             <key>Arguments</key>
             <dict>
                 <key>info_path</key>
-                <string>%pkgroot%/Applications/%NAME%.app</string>
+                <string>%pkgroot%/Applications/XMind.app</string>
                 <key>plist_keys</key>
                 <dict>
                     <key>CFBundleShortVersionString</key>


### PR DESCRIPTION
Because variables can be overridden, it's a good idea to make sure that the recipe will still work even if a non-default variables used. One issue that would prevent recipes from running is using a `NAME` variable in paths that should be hard-coded (e.g. `/Applications/Foo.app`).

This PR removes the `NAME` variable from all file paths and replaces it with the actual app name, which should make the recipe more resilient for overrides.