### PR TITLE
Basic python3 compatibility

### DIFF
--- a/PostProcessors/PatchManagement.py
+++ b/PostProcessors/PatchManagement.py
@@ -15,13 +15,14 @@
 # limitations under the License.
 
 from __future__ import absolute_import
-from autopkglib import Processor, ProcessorError
 
-import json
-import requests
-import os
 import base64
+import os
 import xml.etree.ElementTree as ET
+
+import requests
+
+from autopkglib import Processor, ProcessorError
 
 __all__ = ["PatchManagement"]
 

--- a/PostProcessors/PatchManagement.py
+++ b/PostProcessors/PatchManagement.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from autopkglib import Processor, ProcessorError
 
 import json

--- a/PostProcessors/TeamsPoster.py
+++ b/PostProcessors/TeamsPoster.py
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
+from __future__ import print_function
 from autopkglib import Processor, ProcessorError
 
 import requests
@@ -80,7 +82,7 @@ class TeamsPoster(Processor):
         trigger = True
 
         if trigger_key in processor_summary_result["data"].keys():
-            print "Trigger key: ", trigger_key
+            print("Trigger key: ", trigger_key)
             # trigger = processor_summary_result["data"][trigger_key]
             trigger = False if not processor_summary_result["data"][trigger_key] else True
 

--- a/PostProcessors/TeamsPoster.py
+++ b/PostProcessors/TeamsPoster.py
@@ -66,7 +66,7 @@ class TeamsPoster(Processor):
         payload["sections"].append(activityTitle)
 
         for entry in summary_result["data"]:
-            # print "{0} : {1}".format(entry, summary_result["data"][entry])
+            # print("{0} : {1}".format(entry, summary_result["data"][entry]))
             key_summary={
                 "name": entry,
                 "value": summary_result["data"][entry]

--- a/PostProcessors/TeamsPoster.py
+++ b/PostProcessors/TeamsPoster.py
@@ -14,11 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import print_function
-from autopkglib import Processor, ProcessorError
+from __future__ import absolute_import, print_function
 
 import requests
+
+from autopkglib import Processor, ProcessorError
 
 __all__ = ["TeamsPoster"]
 

--- a/SharedProcessors/DmgConverterLicense.py
+++ b/SharedProcessors/DmgConverterLicense.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
+from __future__ import print_function
 import subprocess
 import time
 import shutil
@@ -33,7 +35,7 @@ class DmgConverterLicense(Processor):
         new_dmg = re.sub(".dmg","",dmg)+"_Converted"
         #####Remove a license agreement from the dmg
         subprocess.check_call(["/usr/bin/hdiutil","convert","-quiet",dmg,"-format","UDTO","-o",new_dmg ])
-        print new_dmg+".cdr"
+        print(new_dmg+".cdr")
         shutil.move(new_dmg+".cdr",new_dmg+".dmg")
         self.env["pathname"] = new_dmg+".dmg"
 

--- a/SharedProcessors/DmgConverterLicense.py
+++ b/SharedProcessors/DmgConverterLicense.py
@@ -1,14 +1,12 @@
 #!/usr/bin/env python
 
-from __future__ import absolute_import
-from __future__ import print_function
-import subprocess
-import time
-import shutil
+from __future__ import absolute_import, print_function
+
 import re
+import shutil
+import subprocess
 
 from autopkglib import Processor, ProcessorError
-from autopkglib.DmgMounter import DmgMounter
 
 __all__ = ["DmgConverterLicense"]
 
@@ -20,16 +18,16 @@ class DmgConverterLicense(Processor):
             "description": "string",
         },
     }
-    
+
     output_variables = {
         "pathname":{
             "required": True,
             "description": "Path to the converted file.",
         },
     }
-   
+
     description = __doc__
-     
+
     def main(self):
         dmg = self.env["dmg_path"]
         new_dmg = re.sub(".dmg","",dmg)+"_Converted"

--- a/SharedProcessors/DmgConverterLicense.py
+++ b/SharedProcessors/DmgConverterLicense.py
@@ -30,7 +30,7 @@ class DmgConverterLicense(Processor):
 
     def main(self):
         dmg = self.env["dmg_path"]
-        new_dmg = re.sub(".dmg","",dmg)+"_Converted"
+        new_dmg = re.sub(r".dmg","",dmg)+"_Converted"
         #####Remove a license agreement from the dmg
         subprocess.check_call(["/usr/bin/hdiutil","convert","-quiet",dmg,"-format","UDTO","-o",new_dmg ])
         print(new_dmg+".cdr")

--- a/SharedProcessors/RenameVar.py
+++ b/SharedProcessors/RenameVar.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
 from autopkglib import Processor, ProcessorError
 
 

--- a/SharedProcessors/RenameVar.py
+++ b/SharedProcessors/RenameVar.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 
 from __future__ import absolute_import
-from autopkglib import Processor, ProcessorError
 
+from autopkglib import Processor, ProcessorError
 
 __all__ = ["RenameVar"]
 

--- a/SharedProcessors/TextSubstituer.py
+++ b/SharedProcessors/TextSubstituer.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python
 
 from __future__ import absolute_import
-import re
-from autopkglib import Processor, ProcessorError
 
+import re
+
+from autopkglib import Processor, ProcessorError
 
 __all__ = ["TextSubstituer"]
 

--- a/SharedProcessors/TextSubstituer.py
+++ b/SharedProcessors/TextSubstituer.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
 import re
 from autopkglib import Processor, ProcessorError
 


### PR DESCRIPTION
In order to make your processors more compatible with AutoPkg running in Python 3, I've applied a few adjustments suggested by `python-modernize`, `pylint --py3k`, and `pylint` in general.

More adjustments may need to be made manually later, but this should catch the low-hanging fruit right now.