### PR TITLE
Remove unused BUNDLE_ID input var

### DIFF
--- a/OpenBoard/OpenBoard.jss.recipe
+++ b/OpenBoard/OpenBoard.jss.recipe
@@ -8,18 +8,16 @@
 	<string>com.github.sebtomasi.jss.OpenBoard</string>
 	<key>Input</key>
 	<dict>
-		<key>NAME</key>
-		<string>OpenBoard</string>
-		<key>CONFIG_FILE</key>
-        <string>OpenBoard.config</string>
 		<key>CATEGORY</key>
 		<string>Productivity</string>
+		<key>CONFIG_FILE</key>
+		<string>OpenBoard.config</string>
 		<key>GROUP_NAME</key>
 		<string>%NAME%-update-smart</string>
 		<key>GROUP_TEMPLATE</key>
 		<string>SmartGroupTemplate.xml</string>
-		<key>BUNDLE_ID</key>
-		<string>org.oe-f.OpenBoard</string>
+		<key>NAME</key>
+		<string>OpenBoard</string>
 		<key>POLICY_CATEGORY</key>
 		<string>Testing</string>
 		<key>POLICY_TEMPLATE</key>


### PR DESCRIPTION
This pull request removes unused instances of `BUNDLE_ID` from recipe input variables, which will help reduce confusion by new AutoPkg users and simplify overrides created from this point on.

Making `BUNDLE_ID` available as an input variable is a common practice in AutoPkg recipes that use the [PkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-PkgCreator) processor ([example](https://github.com/autopkg/homebysix-recipes/blob/4fec9244a3af0f9b7c8f61f35a5cd7f4622fb162/soma-zone/LaunchControl.pkg.recipe#L40-L41)). It's likely that these recipes transitioned from PkgCreator to the more streamlined [AppPkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-AppPkgCreator) processor some time ago, but the now-unused input variable for `BUNDLE_ID` was never removed.

Because an automated script helped make this change, modified recipes have also been converted to align with the output of `plutil -convert xml` and Python's `plistlib`. This results in reordering of dictionary keys and reindentation using tabs, neither of which will affect the recipe's function.
