### PR TITLE
Add glob to LibreOffice langpack tarball path

### DIFF
--- a/LibreOffice/LibreOfficeLangPack.pkg.recipe
+++ b/LibreOffice/LibreOfficeLangPack.pkg.recipe
@@ -64,7 +64,7 @@
 				<key>destination_path</key>
 				<string>%RECIPE_CACHE_DIR%</string>
 				<key>source_path</key>
-				<string>%pathname%/LibreOffice Language Pack.app/Contents/tarball.tar.bz2</string>
+				<string>%pathname%/LibreOffice Language Pack.app/**/tarball.tar.bz2</string>
 			</dict>
 			<key>Processor</key>
 			<string>Copier</string>


### PR DESCRIPTION
This should be merged only after the https://github.com/autopkg/autopkg/pull/711 is released.
**TODO** Bump the required AutoPkg version.

Fixes #17 
