### PR TITLE
Deprecate LibreOffice language pack recipes

### DIFF
--- a/LibreOffice/LibreOfficeLangPack.download.recipe
+++ b/LibreOffice/LibreOfficeLangPack.download.recipe
@@ -16,11 +16,20 @@
 		<string>still</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.2.0</string>
+	<string>1.1</string>
 	<key>ParentRecipe</key>
 	<string>io.github.hjuutilainen.download.LibreOffice</string>
 	<key>Process</key>
 	<array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to the LibreOfficeLangPack recipes in the wycomco-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
 		<dict>
 			<key>Processor</key>
 			<string>com.github.sebtomasi.SharedProcessors/RenameVar</string>


### PR DESCRIPTION
The non-functional LibreOffice language pack recipes in this repo are redundant with the functional ones in the wycomo-recipes repo. This PR deprecates these recipes and points users to alternatives.
