### PR TITLE
Update all available URLs from HTTP to HTTPS

### DIFF
--- a/JetPhoto Studio/JetPhotoStudio.download.recipe
+++ b/JetPhoto Studio/JetPhotoStudio.download.recipe
@@ -15,7 +15,7 @@
         <key>SEARCH_PATTERN</key>
         <string>(JetPhoto_Studio_mac[0-9].[0-9].zip)</string>
         <key>DL_URL</key>
-        <string>http://www.jetphotosoft.com/web/download/</string>
+        <string>https://www.jetphotosoft.com/web/download/</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.2.9</string>

--- a/Silhouette Studio/SilhouetteStudio.download.recipe
+++ b/Silhouette Studio/SilhouetteStudio.download.recipe
@@ -13,7 +13,7 @@
             <key>SEARCH_URL</key>
             <string>https://silhouettefr.fr/silhouette_logiciel.html</string>
             <key>DL_URL</key>
-            <string>http://silhouettefr.fr/file</string>
+            <string>https://silhouettefr.fr/file</string>
             <key>SEARCH_PATTERN</key>
             <string>(Version [\d.]+)</string>
             <key>USER_AGENT</key>

--- a/Silhouette Studio/SilhouetteStudio.pkg.recipe
+++ b/Silhouette Studio/SilhouetteStudio.pkg.recipe
@@ -13,7 +13,7 @@
             <key>SEARCH_URL</key>
             <string>https://silhouettefr.fr/silhouette_logiciel.html</string>
             <key>DL_URL</key>
-            <string>http://silhouettefr.fr/file</string>
+            <string>https://silhouettefr.fr/file</string>
             <key>SEARCH_PATTERN</key>
             <string>(Version [\d.]+)</string>
             <key>USER_AGENT</key>


### PR DESCRIPTION
It's important to use HTTPS for downloading software whenever possible in order to avoid the possibility of person-in-the-middle attacks (like the one that affected the Sparkle update framework [back in 2016](https://vulnsec.com/2016/osx-apps-vulnerabilities/)).

For this pull request, I detected and changed to HTTPS URLs automatically using my [HTTPS Spotter](https://www.elliotjordan.com/posts/autopkg-https/) script, and then tested all changed recipes manually to ensure exit codes of recipe run remains the same before/after the change.

Thanks for considering!

_This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0._