### PR TITLE
Removal of unused `options` from PkgCreator arguments

### DIFF
--- a/Anki/Anki.pkg.recipe
+++ b/Anki/Anki.pkg.recipe
@@ -72,8 +72,6 @@
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>id</key>
 					<string>%bundleid%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
                     <key>scripts</key>
 					<string></string>
 					<key>chown</key>

--- a/Batch Image Resizer/BatchImageResizer.pkg.recipe
+++ b/Batch Image Resizer/BatchImageResizer.pkg.recipe
@@ -73,8 +73,6 @@
                     <string>%version%</string>
                     <key>id</key>
                     <string>%bundleid%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/CaRMetal/CaRMetal.pkg.recipe
+++ b/CaRMetal/CaRMetal.pkg.recipe
@@ -71,8 +71,6 @@
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>id</key>
 					<string>%bundleid%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
                     <key>scripts</key>
 					<string></string>
 					<key>chown</key>

--- a/Cukydata/Cukydata.pkg.recipe
+++ b/Cukydata/Cukydata.pkg.recipe
@@ -90,8 +90,6 @@
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>id</key>
 					<string>%bundleid%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
                     <key>scripts</key>
 					<string></string>
 					<key>chown</key>

--- a/ICanAnimate2/ICanAnimate2.pkg.recipe
+++ b/ICanAnimate2/ICanAnimate2.pkg.recipe
@@ -95,8 +95,6 @@
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>
                     <string>%bundleid%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/Intaglio/Intaglio.pkg.recipe
+++ b/Intaglio/Intaglio.pkg.recipe
@@ -128,8 +128,6 @@
                         <string>%RECIPE_CACHE_DIR%</string>
                         <key>id</key>
                         <string>%bundleid%</string>
-                        <key>options</key>
-                        <string>purge_ds_store</string>
                         <key>scripts</key>
                         <string></string>
                         <key>chown</key>

--- a/JetPhoto Studio/JetPhotoStudio.pkg.recipe
+++ b/JetPhoto Studio/JetPhotoStudio.pkg.recipe
@@ -71,8 +71,6 @@
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>id</key>
 					<string>%bundleid%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
                     <key>scripts</key>
 					<string></string>
 					<key>chown</key>

--- a/LegoMindstormsEducation/LegoMindstormsEducation.pkg.recipe
+++ b/LegoMindstormsEducation/LegoMindstormsEducation.pkg.recipe
@@ -77,8 +77,6 @@
 					</array>
 					<key>id</key>
 					<string>%bundleid%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgdir</key>
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>pkgname</key>

--- a/LibreOffice/LibreOfficeLangPack.pkg.recipe
+++ b/LibreOffice/LibreOfficeLangPack.pkg.recipe
@@ -98,8 +98,6 @@
 					</array>
 					<key>id</key>
 					<string>org.libreoffice.langpack-%LANGUAGE_CODE%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgdir</key>
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>pkgname</key>

--- a/OpenBoard/OpenBoard.pkg.recipe
+++ b/OpenBoard/OpenBoard.pkg.recipe
@@ -84,8 +84,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgdir</key>
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>pkgname</key>

--- a/XMind/XMind.pkg.recipe
+++ b/XMind/XMind.pkg.recipe
@@ -71,8 +71,6 @@
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>id</key>
 					<string>%bundleid%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
                     <key>scripts</key>
 					<string></string>
 					<key>chown</key>


### PR DESCRIPTION
Hundreds of recipes dating from the very beginning of AutoPkg use the `options` key in the `pkg_request` argument of PkgCreator:

```xml
<key>options</key>
<string>purge_ds_store</string>
```

However, this key doesn't serve any purpose at all. The `options` key is ignored and not passed along to `pkgbuild`, regardless of its presence or contents. It appears that this has been the case since the very first public release of AutoPkg 0.1.0!

So this pull request (one of over 100) formally ends this practice and removes the unused and unneeded `options` key from all recipes in the AutoPkg org that use PkgCreator.

Thanks for considering!

_This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0._